### PR TITLE
fix crash on recent firmware

### DIFF
--- a/src/gui_manager.c
+++ b/src/gui_manager.c
@@ -167,6 +167,7 @@ GuiManager* GuiManagerAlloc(void) {
   manager->gui = furi_record_open(RECORD_GUI);
   manager->dialogs = furi_record_open(RECORD_DIALOGS);
   manager->view_dispatcher = view_dispatcher_alloc();
+  view_dispatcher_enable_queue(manager->view_dispatcher);
   view_dispatcher_attach_to_gui(manager->view_dispatcher, manager->gui, ViewDispatcherTypeFullscreen);
   view_dispatcher_set_event_callback_context(manager->view_dispatcher, manager);
   view_dispatcher_set_custom_event_callback(manager->view_dispatcher, CustomEventCallback);


### PR DESCRIPTION
This pull request fixes an instant crash of the app at startup. I built the app for a fairly recent version of Roguemaster, and found that call to `view_dispatcher_run()` must be preceded by `view_dispatcher_enable_queue()`. This trivial change adds that. Fixes #3 .